### PR TITLE
Fix missing name attribute

### DIFF
--- a/src/components/Email/index.js
+++ b/src/components/Email/index.js
@@ -14,6 +14,7 @@ function Email(props) {
   return (
     <input 
       type="email"
+      name="email"
       placeholder={props.placeholder ? props.placeholder : 'email@site.com'}
       required
       { ...props }


### PR DESCRIPTION
Without this, TinyLetter would prompt the user for email again after submitting the form.